### PR TITLE
feat: Remove Anthropic and Claude branding from frontend

### DIFF
--- a/frontend/src/app/Chat/Chat.tsx
+++ b/frontend/src/app/Chat/Chat.tsx
@@ -331,7 +331,7 @@ const Chat: React.FunctionComponent<IChatProps> = () => {
                   content={message.text}
                   timestamp={message.timestamp.toLocaleTimeString()}
                   avatar={message.sender === 'user' ? avatarImg : aiLogo}
-                  name={message.sender === 'user' ? 'You' : 'Claude AI'}
+                  name={message.sender === 'user' ? 'You' : 'AI Assistant'}
                   isLoading={isLastBotMessage}
                   extraContent={message.sender === 'bot' ? {
                     afterMainContent: <ImagePreview content={message.text} />
@@ -345,7 +345,7 @@ const Chat: React.FunctionComponent<IChatProps> = () => {
                 role="bot"
                 content=""
                 avatar={aiLogo}
-                name="Claude AI"
+                name="AI Assistant"
                 isLoading
               />
             )}
@@ -361,7 +361,7 @@ const Chat: React.FunctionComponent<IChatProps> = () => {
             onChange={(_event, value) => setInputValue(value as string)}
             placeholder="Type your message..."
           />
-          <ChatbotFootnote label="Powered by Claude AI" />
+          <ChatbotFootnote label="AI-Powered Chat" />
         </ChatbotFooter>
       </Chatbot>
     </PageSection>


### PR DESCRIPTION
## Summary
This PR removes all vendor-specific branding (Anthropic/Claude) from the frontend to make the application vendor-neutral.

## Changes
- Replace "Claude AI" with "AI Assistant" in chat message sender names
- Update footer from "Powered by Claude AI" to generic "AI-Powered Chat" label
- No functional changes, only branding updates

## Motivation
Making the frontend vendor-neutral allows the application to work with any AI backend service without displaying specific vendor branding.

## Testing
- ✅ TypeScript compilation successful
- ✅ All references to Claude/Anthropic removed from frontend code
- ✅ Application remains fully functional with generic branding

## Files Modified
- `frontend/src/app/Chat/Chat.tsx` - 3 branding updates